### PR TITLE
Add missing keyword identifier

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -14,7 +14,7 @@ read	KEYWORD2
 setResetPin	KEYWORD2
 setStrobePin	KEYWORD2
 setAnalogPin	KEYWORD2
-setDelay
+setDelay	KEYWORD2
 
 ##################################################
 #  setup and loop functions, and Serial (KEYWORD3)


### PR DESCRIPTION
The missing identifier caused the setDelay keyword not to be recognized by the Arduino IDE for special highlighting.